### PR TITLE
Fix for 'No space left on device' errors

### DIFF
--- a/neo/load.sh
+++ b/neo/load.sh
@@ -22,6 +22,7 @@ docker run \
     --publish=7474:7474 \
     --publish=7687:7687 \
     --volume=${NEO4J_DATA_DIR}:/data:z \
+    --volume=${NEO4J_HOME}/logs:/logs:z \
     --volume=${IMPORT_DATA_DIR_PROJECTED_FK}:/import:z \
     ${NEO4J_ENV_VARS} \
     neo4j:${NEO4J_VERSION} \

--- a/pos/scratch/.gitignore
+++ b/pos/scratch/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+

--- a/pos/start.sh
+++ b/pos/start.sh
@@ -15,6 +15,7 @@ docker run \
     --name ${POSTGRES_CONTAINER_NAME} \
     --env ${POSTGRES_PASSWORD_POLICY} \
     --volume=${IMPORT_DATA_DIR_MERGED_FK}:/data:z \
+	--volume=${POSTGRES_HOME}:/var/lib/postgresql/data:z \
     --detach \
     --shm-size=${POSTGRES_SHARED_MEMORY} \
     postgres:${POSTGRES_VERSION}

--- a/pos/vars.sh
+++ b/pos/vars.sh
@@ -1,3 +1,4 @@
+export POSTGRES_HOME=`pwd`/pos/scratch
 export POSTGRES_VERSION=13.1
 export POSTGRES_SCHEMA_DIR=`pwd`/sql
 export POSTGRES_CONTAINER_NAME=lsqb-pos

--- a/sql/drop.sql
+++ b/sql/drop.sql
@@ -10,6 +10,8 @@ DROP TABLE IF exists University;
 DROP TABLE IF exists Continent;
 DROP TABLE IF exists Country;
 DROP TABLE IF exists City;
+DROP TABLE IF exists Tag;
+DROP TABLE IF exists TagClass;
 DROP TABLE IF exists Forum;
 DROP TABLE IF exists Comment;
 DROP TABLE IF exists Post;


### PR DESCRIPTION
Fixes #61 

The errors are probably caused by missing write permissions to system directories. Using a scratch directory for postgres' data location `/var/lib/postgresql/data` and mounting the `scratch/logs` directory when loading the neo4j database (as done in `neo/start.sh`) resolves the problems.

I also added DROP TABLE statements for Tag and TagClass in `sql/drop.sql`. Without them, postgres warns when reloading the dataset and yields differing results for query 1.

I did not test systems other than umb, neo and pos. Similar issues might occur for the other dbs.