### PR TITLE
Remove pos/scratch directory, add it to pos/.gitignore

### DIFF
--- a/pos/.gitignore
+++ b/pos/.gitignore
@@ -1,0 +1,1 @@
+scratch/

--- a/pos/scratch/.gitignore
+++ b/pos/scratch/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -23,7 +23,7 @@ pip3 install --user --progress-bar off duckdb==${DUCKDB_VERSION}
 pip3 install --user --progress-bar off neo4j
 pip3 install --user --progress-bar off pymgclient
 pip3 install --user --progress-bar off wheel
-pip3 install --user --progress-bar off redisgraph redisgraph-bulk-loader
+pip3 install --user --progress-bar off redisgraph redisgraph-bulk-loader pathos
 pip3 install --user --progress-bar off psycopg2-binary
 pip3 install --user --progress-bar off mysql-connector-python
 pip3 install --user --progress-bar off SPARQLWrapper


### PR DESCRIPTION
This change is required to avoid having a non-empty scratch directory with a
dotfile (.gitignore).